### PR TITLE
Fix to handle null/empty values in the UPI Response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,9 @@ Sample response of failure payment
 # 1.0.1:
   Added capability to fetch all UPI supported apps rather than predefined list (added in 1.0.0v)
   Added capability to send upi app details used for payment, in response.
+
+#1.0.2:
+Bug fix related to defensive check on "Status" field.
+
+# 1.0.3:
+Bug fix related to defensive check on the intent extras for value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-upi",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "This Plugin allows you receive payment via UPI.",
   "main": "www/upi.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" 
-    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-upi" version="1.0.1">
+    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-upi" version="1.0.3">
     <name>UPI</name>
 
     <description>This Plugin allows you receive payment via UPI.</description>

--- a/src/android/UPIPlugin.java
+++ b/src/android/UPIPlugin.java
@@ -228,13 +228,22 @@ public class UPIPlugin extends CordovaPlugin {
 
     private void parseUpiResponse(String upi_response, JSONObject json) throws JSONException {
         String[] _parts = upi_response.split("&");
+        try {
         for (int i = 0; i < _parts.length; ++i) {
             String key = _parts[i].split("=")[0];
-            String value = _parts[i].split("=")[1];
+            String value = null;
+            if(_parts[i].split("=").length > 1) {
+            	// To handle response => txnId=1614149099033&responseCode=00&ApprovalRefNo=&Status=SUCCESS&txnRef=1614149099033;
+            	// ApprovalRefNo=
+            	value = _parts[i].split("=")[1];
+            }
             json.put(key, value);
             if ("status".equalsIgnoreCase(key)) {
                 json.put("status", value);
             }
+        }
+        } catch(Exception e) {
+        	Log.e(TAG, "Error while parsing UPI Response: " + e.toString());
         }
     }
 


### PR DESCRIPTION
// To handle response => txnId=1614149099033&responseCode=00&ApprovalRefNo=&Status=SUCCESS&txnRef=1614149099033;
            	// ApprovalRefNo=
            	value = _parts[i].split("=")[1]; This fails... as there is no value element in the array.